### PR TITLE
feat: emit file on build

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,10 +70,11 @@ const App = () => {
 
 ## Options
 
-| Option         | Type                                 | Description                                                                                   |
-| -------------- | ------------------------------------ | --------------------------------------------------------------------------------------------- |
-| `pattern`      | `string`                             | A glob pattern that specifies which SVG files to include in the sprite.                       |
-| `prefix`       | `string` (optional)                  | A string that is added to the beginning of each SVG icon's ID when it is added to the sprite. |
-| `filename`     | `string` (optional)                  | The name of the output file that contains the SVG sprite. Default is `spritemap.svg`.         |
-| `currentColor` | `boolean` (optional)                 | Replace colors in the SVGs with the `currentColor` value by SVGO. Default is `false`.          |
-| `svgo`         | `SVGOConfig` or `boolean` (optional) | Use SVGO for optimization. Default is `true`.                                                 |
+| Option         | Type                                 | Description                                                                                                 |
+| -------------- | ------------------------------------ |-------------------------------------------------------------------------------------------------------------|
+| `pattern`      | `string`                             | A glob pattern that specifies which SVG files to include in the sprite.                                     |
+| `prefix`       | `string` (optional)                  | A string that is added to the beginning of each SVG icon's ID when it is added to the sprite.               |
+| `filename`     | `string` (optional)                  | The name of the output file that contains the SVG sprite. Default is `spritemap.svg`.                       |
+| `currentColor` | `boolean` (optional)                 | Replace colors in the SVGs with the `currentColor` value by SVGO. Default is `false`.                       |
+| `svgo`         | `SVGOConfig` or `boolean` (optional) | Use SVGO for optimization. Default is `true`.                                                               |
+| `emit`         | `boolean` (optional)                 | Additionally emit the file so that other vite plugins can process it (eg. compression). Default is `false`. |

--- a/src/index.ts
+++ b/src/index.ts
@@ -11,6 +11,7 @@ export interface SvgSpritemapOptions {
   filename?: string;
   svgo?: SVGOConfig | boolean;
   currentColor?: boolean;
+  emit?: boolean;
 }
 
 const PLUGIN_NAME = 'vite-plugin-svg-spritemap';
@@ -21,6 +22,7 @@ export function svgSpritemap({
   filename = 'spritemap.svg',
   svgo = true,
   currentColor = false,
+  emit = false,
 }: SvgSpritemapOptions): Plugin[] {
   let config: ResolvedConfig;
   let watcher: FSWatcher;
@@ -37,6 +39,14 @@ export function svgSpritemap({
         const filePath = path.resolve(config.root, config.build.outDir, filename);
         fs.ensureFileSync(filePath);
         fs.writeFileSync(filePath, sprite);
+
+        if (emit) {
+          this.emitFile({
+            type: 'asset',
+            fileName: filename,
+            source: sprite,
+          });
+        }
       },
     },
     {


### PR DESCRIPTION
Hi, it's me again 🙂 

I noticed that the plugin wrote its output on disk but didn't emit the file. It's something that could be super useful to do further processing, like in our case also write gzipped & brotlified versions of the same file. I set it with a flag but it might not even be necessary, I just thought you might not want this behavior by default.